### PR TITLE
If eslint doesn't fix anything, output is undefined

### DIFF
--- a/bin/eslint-fix.js
+++ b/bin/eslint-fix.js
@@ -10,6 +10,11 @@ process.stdin.on('data', function(data) {
         cliEngine = new CLIEngine({fix: true})
         report = cliEngine.executeOnText(input)
         output = report.results[0].output
+
+        if (!output) {
+          // if no fixes were made, output is undefined
+          output = input
+        }
     } catch (err) {
         // Missing `eslint`, `.eslintrc`
         // process.stderr.write(err)


### PR DESCRIPTION
with eslint v3.9.0, there are some files that I run eslint-fix against that don't require any fixes by eslint, but eslint leaves report.results[0].output undefined:

eml@brainpal ~/git/developer.feed.fm (apm)*$ cat app/webroot/js/view/search.js | eslint-fix
net.js:648
    throw new TypeError(
    ^

TypeError: Invalid data, chunk must be a string or buffer, not undefined
    at WriteStream.Socket.write (net.js:648:11)
    at Socket.<anonymous> (/Users/eml/.nvm/versions/node/v6.7.0/lib/node_modules/eslint-fix/bin/eslint-fix.js:18:20)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)

I originally thought this always happened when eslint didn't fix anything, but that isn't the case - it only happens in some cases that I haven't been able to narrow to down just yet. In the meantime, this tweak ensures that ggVG= still works for me in vi.
